### PR TITLE
feat: wrap Tern output in container

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -63,8 +63,6 @@ jobs:
           context: .
           load: true
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Reformat digest for use in names
         # Note: image ID is written to digest https://github.com/docker/build-push-action/issues/579
@@ -88,7 +86,7 @@ jobs:
       - name: Run Tern
         run: tern report -o tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt -w ${{ github.event.repository.name }}.tar
 
-      - name: Build a Docker container wrapping the Tern output
+      - name: Create a Dockerfile to wrap the Tern output
         run: |
           echo -e "FROM ${{ env.IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
@@ -102,6 +100,16 @@ jobs:
         with:
           name: tern-output-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}
           path: ${{ github.workspace }}/tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt
+
+      - name: Build final image
+        id: build
+        with:
+          context: .
+          file: 'Dockerfile-wrapper'
+          load: true
+          push: false
+          tags: ${{ steps.meta.output.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Push Docker image
         # Only push on main branch

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -38,17 +38,6 @@ jobs:
       - name: Store date in variable
         run: echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=builder-sha-${{ env.REPO_SHA }}
-            type=raw,value=date-${{ env.DATE }}
-            type=raw,value=ort-sha-${{ env.ORT_SHA }}
-            type=raw,value=latest
-
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -86,11 +75,16 @@ jobs:
       - name: Run Tern
         run: tern report -o tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt -w ${{ github.event.repository.name }}.tar
 
-      - name: Create a Dockerfile to wrap the Tern output
+      - name: Build container that wraps the Tern output
         run: |
           echo -e "FROM ${{ env.SHORT_IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
-          #docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
+          docker build \
+          -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:builder-sha-${{ env.REPO_SHA }} \
+          -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:date-${{ env.DATE }} \
+          -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ort-sha-${{ env.ORT_SHA }} \
+          -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          -f Dockerfile-wrapper .
 
       - name: List image digests
         run: docker images --digests
@@ -100,16 +94,6 @@ jobs:
         with:
           name: tern-output-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}
           path: ${{ github.workspace }}/tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt
-
-      - name: Build final image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: 'Dockerfile-wrapper'
-          load: true
-          push: false
-          tags: ${{ steps.meta.output.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Push Docker image
         # Only push on main branch

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -88,9 +88,9 @@ jobs:
 
       - name: Create a Dockerfile to wrap the Tern output
         run: |
-          echo -e "FROM ${{ env.IMAGE_ID_FULL }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
+          echo -e "FROM ${{ env.SHORT_IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
-          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
+          #docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
 
       - name: List image digests
         run: docker images --digests

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -74,7 +74,6 @@ jobs:
           echo "SHORT_IMAGE_ID=`echo ${{ steps.build.outputs.digest }} | sed s/sha256:// | cut -c1-12`" >> $GITHUB_ENV
 
       - name: Install Tern
-        if: false
         run: |
           sudo apt install git attr python3 python3-pip jq skopeo
           sudo pip install pipx
@@ -84,11 +83,9 @@ jobs:
         run: docker images --digests
 
       - name: Save container as a tar archive for local scanning
-        if: false
         run: docker save -o ${{ github.event.repository.name }}.tar ${{ env.IMAGE_ID }}
 
       - name: Run Tern
-        if: false
         run: tern report -o tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt -w ${{ github.event.repository.name }}.tar
 
       - name: Build a Docker container wrapping the Tern output
@@ -101,7 +98,6 @@ jobs:
         run: docker images --digests
 
       - name: Store results
-        if: false
         uses: actions/upload-artifact@v3
         with:
           name: tern-output-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     - cron: '22 11 * * *'  # Trigger daily at 11:22 UTC'
   workflow_dispatch: # allow manual triggering
+  push:
 
 env:
   REGISTRY: ghcr.io
@@ -57,6 +58,7 @@ jobs:
 
       - name: Build and tag Docker image
         id: build
+        if: false
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -73,6 +75,7 @@ jobs:
           echo "SHORT_IMAGE_ID=`echo ${{ steps.build.outputs.digest }} | sed s/sha256:// | cut -c1-12`" >> $GITHUB_ENV
 
       - name: Install Tern
+        if: false
         run: |
           sudo apt install git attr python3 python3-pip jq skopeo
           sudo pip install pipx
@@ -82,20 +85,24 @@ jobs:
         run: docker images --digests
 
       - name: Save container as a tar archive for local scanning
+        if: false
         run: docker save -o ${{ github.event.repository.name }}.tar ${{ env.IMAGE_ID }}
 
       - name: Run Tern
+        if: false
         run: tern report -o tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt -w ${{ github.event.repository.name }}.tar
 
       - name: Build a Docker container wrapping the Tern output
         run: |
           echo -e "FROM {{ env.IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
+          cat Dockerfile-wrapper
           docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
 
       - name: List image digests
         run: docker images --digests
 
       - name: Store results
+        if: false
         uses: actions/upload-artifact@v3
         with:
           name: tern-output-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Build final image
         id: build
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: 'Dockerfile-wrapper'

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -102,7 +102,6 @@ jobs:
           path: ${{ github.workspace }}/tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt
 
       - name: Build final image
-        id: build
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -80,10 +80,10 @@ jobs:
           echo -e "FROM ${{ env.SHORT_IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
           docker build \
-          --label org.opencontainers.image.title=ort-containers.image.title=ort-container \
+          --label org.opencontainers.image.title=ort-containers.image.title=${{ github.event.repository.name }} \
           --label ort.opencontainers.image.description="A temporary solution to provide a ORT Container." \
-          --label org.opencontainers.image.url="https://github.com/alliander-opensource/ort-container" \
-          --label org.opencontainers.image.source="https://github.com/alliander-opensource/ort-container" \
+          --label org.opencontainers.image.url="${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}" \
+          --label org.opencontainers.image.source="${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}" \
           -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:builder-sha-${{ env.REPO_SHA }} \
           -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:date-${{ env.DATE }} \
           -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ort-sha-${{ env.ORT_SHA }} \

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -30,7 +30,8 @@ jobs:
         run: echo "ORT_SHA=$(/usr/bin/git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Lowercase image name based on repo
-        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+        # TODO: integrate image names before merging
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}-tmp" >> ${GITHUB_ENV}
 
       - name: Shorten repo SHA
         run: echo "REPO_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
@@ -102,5 +103,5 @@ jobs:
       - name: Push Docker image
         # Only push on main branch
         # TODO: push the wrapped container instead of the original one
-        if: github.ref == 'refs/heads/main'
+        #if: github.ref == 'refs/heads/main'
         run: docker image push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Build and tag Docker image
         id: build
-        if: false
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -80,6 +80,10 @@ jobs:
           echo -e "FROM ${{ env.SHORT_IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
           docker build \
+          --label org.opencontainers.image.title=ort-containers.image.title=ort-container \
+          --label ort.opencontainers.image.description="A temporary solution to provide a ORT Container." \
+          --label org.opencontainers.image.url="https://github.com/alliander-opensource/ort-container" \
+          --label org.opencontainers.image.source="https://github.com/alliander-opensource/ort-container" \
           -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:builder-sha-${{ env.REPO_SHA }} \
           -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:date-${{ env.DATE }} \
           -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ort-sha-${{ env.ORT_SHA }} \

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -101,6 +101,5 @@ jobs:
 
       - name: Push Docker image
         # Only push on main branch
-        # TODO: push the wrapped container instead of the original one
         if: github.ref == 'refs/heads/main'
         run: docker image push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create a Dockerfile to wrap the Tern output
         run: |
-          echo -e "FROM ${{ env.IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
+          echo -e "FROM ${{ env.IMAGE_ID_FULL }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
           docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
 

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build a Docker container wrapping the Tern output
         run: |
-          echo -e "FROM {{ env.IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
+          echo -e "FROM ${{ env.IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
           cat Dockerfile-wrapper
           docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
 

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -87,6 +87,14 @@ jobs:
       - name: Run Tern
         run: tern report -o tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt -w ${{ github.event.repository.name }}.tar
 
+      - name: Build a Docker container wrapping the Tern output
+        run: |
+          echo -e "FROM {{ env.IMAGE_ID }}\nCOPY tern-analysis-${{ env.DATE }}-${{ env.SHORT_IMAGE_ID }}.txt ./" > Dockerfile-wrapper
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:wrapped -f Dockerfile-wrapper .
+
+      - name: List image digests
+        run: docker images --digests
+
       - name: Store results
         uses: actions/upload-artifact@v3
         with:
@@ -95,5 +103,6 @@ jobs:
 
       - name: Push Docker image
         # Only push on main branch
+        # TODO: push the wrapped container instead of the original one
         if: github.ref == 'refs/heads/main'
         run: docker image push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -30,8 +30,7 @@ jobs:
         run: echo "ORT_SHA=$(/usr/bin/git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Lowercase image name based on repo
-        # TODO: integrate image names before merging
-        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}-tmp" >> ${GITHUB_ENV}
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
 
       - name: Shorten repo SHA
         run: echo "REPO_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
@@ -103,5 +102,5 @@ jobs:
       - name: Push Docker image
         # Only push on main branch
         # TODO: push the wrapped container instead of the original one
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: docker image push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
Add the Tern output to the container as a final step to provide more
copyright and license information to the container users.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>