### PR TITLE
feat: build new Docker PR

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -22,10 +22,10 @@ jobs:
             suffix: ''
             description: 'Main branch'
             image_url: 'https://github.com/oss-review-toolkit/ort'
-          - ref: 'refs/pull/4746/merge'
-            suffix: '-pr-4746'
-            description: 'Update Dockerfile to use multi-stage builds by heliocastro'
-            image_url: 'https://github.com/oss-review-toolkit/ort/pull/4746'
+          - ref: 'refs/pull/5760/merge'
+            suffix: '-pr-5760'
+            description: 'Docker: Component based Multi stage docker by heliocastro'
+            image_url: 'https://github.com/oss-review-toolkit/ort/pull/5760'
     name: containerize
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Helicastro started a new PR for Docker
https://github.com/oss-review-toolkit/ort/pull/5760 so now build that
one. The older one does no longer need building.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>
